### PR TITLE
Pin scipy and pyfftw for EQcorrscan 0.4.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,12 +34,12 @@ requirements:
     - future
     - {{ pin_compatible('numpy') }}
     - fftw
-    - scipy >=0.18, <1.9.0
+    - scipy <1.9.0
     - matplotlib-base
     - obspy
     - bottleneck
     - pyproj
-    - pyfftw
+    - pyfftw <=0.12
     - h5py
     - llvm-openmp >=4.0.1  # [osx]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - future
     - numpy
     - fftw
+    - pyfftw
     - llvm-openmp >=4.0.1  # [osx]
   run:
     - python
@@ -39,7 +40,7 @@ requirements:
     - obspy
     - bottleneck
     - pyproj
-    - pyfftw <=0.12
+    - pyfftw
     - h5py
     - llvm-openmp >=4.0.1  # [osx]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,20 +27,20 @@ requirements:
     - future
     - numpy
     - fftw
-    - pyfftw
+    - pyfftw ==0.12
     - llvm-openmp >=4.0.1  # [osx]
   run:
     - python
     - setuptools
     - future
     - {{ pin_compatible('numpy') }}
+    - pyfftw ==0.12
     - fftw
     - scipy <1.9.0
     - matplotlib-base
     - obspy
     - bottleneck
     - pyproj
-    - pyfftw
     - h5py
     - llvm-openmp >=4.0.1  # [osx]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 build:
   skip: true  # [win and py==38]
-  number: 0
+  number: 1
 
 
 requirements:

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -109,6 +109,7 @@ def check_c_locations():
 
     
 def test_pyfftw_resample():
+    """ Check that pyfftw works properly with our fftw libs. """"
     import io
     from contextlib import redirect_stdout
     from eqcorrscan.utils.pre_processing import _resample
@@ -121,6 +122,11 @@ def test_pyfftw_resample():
         # If linking not done properly then this will output a traceback to stdout
         tr_resampled = _resample(tr, 50, threads=2)
     assert f.getvalue() == ''
+    
+def test_obspy_resample():
+    """ Check that obspy resample works - scipy hanning to hann name change. """
+    tr = Trace(np.random.randn(360000))
+    tr.resample(50)
     
 
 if __name__ == '__main__':

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -136,3 +136,4 @@ if __name__ == '__main__':
     check_c_locations()
     test_multi_channel_xcorr()
     test_pyfftw_resample()
+    test_obspy_resample()

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -109,7 +109,7 @@ def check_c_locations():
 
     
 def test_pyfftw_resample():
-    """ Check that pyfftw works properly with our fftw libs. """"
+    """ Check that pyfftw works properly with our fftw libs. """
     import io
     from contextlib import redirect_stdout
     from eqcorrscan.utils.pre_processing import _resample

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -107,6 +107,21 @@ def check_c_locations():
     # Load the cdll
     cdll = libnames._load_cdll("libutils")
 
+    
+def test_pyfftw_resample():
+    import io
+    from contextlib import redirect_stdout
+    from eqcorrscan.utils.pre_processing import _resample
+    
+    tr = Trace(np.random.randn(360000))
+    tr.stats.sampling_rate = 100.0
+    
+    f = io.StringIO()
+    with redirect_stdout(f):
+        # If linking not done properly then this will output a traceback to stdout
+        tr_resampled = _resample(tr, 50, n_threads=2)
+    assert f.getvalue() == ''
+    
 
 if __name__ == '__main__':
     """
@@ -114,3 +129,4 @@ if __name__ == '__main__':
     """
     check_c_locations()
     test_multi_channel_xcorr()
+    test_pyfftw_resample()

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -119,7 +119,7 @@ def test_pyfftw_resample():
     f = io.StringIO()
     with redirect_stdout(f):
         # If linking not done properly then this will output a traceback to stdout
-        tr_resampled = _resample(tr, 50, n_threads=2)
+        tr_resampled = _resample(tr, 50, threads=2)
     assert f.getvalue() == ''
     
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
~~* [ ] Reset the build number to `0` (if the version changed)~~
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

This is related to [this issue](https://github.com/eqcorrscan/EQcorrscan/issues/514) in EQcorrscan. Pinning of packages is a temporary fix until obspy is updated to cope with Scipy updates, and EQcorrscan plays nicely with pyfftw.

<!--
Please add any other relevant info below:
-->
